### PR TITLE
Fix path for categories.json.

### DIFF
--- a/src/app/services/categories.service.ts
+++ b/src/app/services/categories.service.ts
@@ -8,7 +8,7 @@ export class CategoriesService {
   constructor(private http: Http){}
 
   getCategories(): Promise<CategoryModel[]> {
-    return this.http.get("./assets/categories.json")
+    return this.http.get("/assets/categories.json")
     .toPromise()
     .then(res => res.json() as CategoryModel[])
   }


### PR DESCRIPTION
Was working through a tutorial based on this project, and noticed when running a production build locally or in S3, I was getting a 404 trying to get categories.json.

<img width="759" alt="182268793-9abfadf7-eed8-4da3-a662-c12bebcc7906" src="https://user-images.githubusercontent.com/645677/182620784-5321fd46-d783-4f5c-aa33-31c2942d94fd.png">

Setting an absolute path here seems to fix it.